### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-python
 
 name: Python package
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/bertcafecito/inkcollector/security/code-scanning/1](https://github.com/bertcafecito/inkcollector/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root of the workflow file. This block will explicitly set the permissions to `contents: read`, which is sufficient for the operations performed in this workflow. This ensures that the workflow does not have unnecessary write permissions, reducing the risk of misuse.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
